### PR TITLE
Heroku support

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
       "env": {
         "NODE_PATH": "./src",
         "NODE_ENV": "production",
-        "PORT": 8080,
         "APIPORT": 3030
       }
     },
@@ -173,6 +172,7 @@
     "webpack-hot-middleware": "^2.5.0"
   },
   "engines": {
+    "npm": "3.5.1",
     "node": "4.1.1"
   }
 }


### PR DESCRIPTION
This also requires that you enable installing `devDependencies` by running `heroku config:set NPM_CONFIG_PRODUCTION=false`.

I didn't pull out the API server, this just removes the config port from production config that was causing the environment variable to be ignored and installs the right `npm` version.

@muffinresearch hopefully this helps.
